### PR TITLE
Retry DOI-based abstract enrichment after title DOI discovery

### DIFF
--- a/src/refweaver/enrich.py
+++ b/src/refweaver/enrich.py
@@ -1031,6 +1031,20 @@ class ArticleEnricher:
                 logger.success("Abstract filled via title search")
                 return article
 
+            # If title search found a DOI but not an abstract, retry DOI-based strategies
+            if article.doi and not article.abstract:
+                if try_cross_api:
+                    article = self._fill_from_cross_api(article)
+                    if article.abstract:
+                        logger.success("Abstract filled via title DOI + cross-API lookup")
+                        return article
+
+                if try_crossref:
+                    article = self.enrich_from_crossref(article)
+                    if article.abstract:
+                        logger.success("Abstract filled via title DOI + CrossRef")
+                        return article
+
         # Strategy 5: Extract DOI from PDF (useful when title search is truncated)
         if try_pdf_doi and not article.doi:
             article = self.enrich_from_pdf_doi(article)

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -5,7 +5,7 @@ import types
 
 
 class _Logger:
-    def __getattr__(self, _name):
+    def __getattr__(self, _name: str):
         return lambda *args, **kwargs: None
 
 
@@ -94,8 +94,6 @@ def test_fill_abstract_retries_doi_strategies_after_title_finds_doi_crossref():
 
     def crossref(a: Article) -> Article:
         calls["crossref"] += 1
-        if calls["crossref"] == 1:
-            return a
         return a.model_copy(update={"abstract": "Filled by crossref"})
 
     enricher._fill_from_cross_api = cross_api
@@ -108,7 +106,7 @@ def test_fill_abstract_retries_doi_strategies_after_title_finds_doi_crossref():
 
     assert result.abstract == "Filled by crossref"
     assert calls["cross_api"] == 2
-    assert calls["crossref"] == 2
+    assert calls["crossref"] == 1
 
 
 def test_fill_abstract_doi_already_present_skips_title_search():

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -1,0 +1,163 @@
+"""Tests for abstract enrichment fallback sequencing."""
+
+import sys
+import types
+
+
+class _Logger:
+    def __getattr__(self, _name):
+        return lambda *args, **kwargs: None
+
+
+# Minimal stubs for optional third-party deps used at import time.
+loguru_stub = types.ModuleType("loguru")
+loguru_stub.logger = _Logger()
+sys.modules.setdefault("loguru", loguru_stub)
+
+pyalex_stub = types.ModuleType("pyalex")
+pyalex_stub.Works = object
+pyalex_stub.config = types.SimpleNamespace(email=None)
+sys.modules.setdefault("pyalex", pyalex_stub)
+
+scholarly_stub = types.ModuleType("scholarly")
+scholarly_stub.ProxyGenerator = object
+scholarly_stub.scholarly = types.SimpleNamespace(use_proxy=lambda *_args, **_kwargs: None)
+sys.modules.setdefault("scholarly", scholarly_stub)
+
+semanticscholar_stub = types.ModuleType("semanticscholar")
+semanticscholar_stub.SemanticScholar = object
+sys.modules.setdefault("semanticscholar", semanticscholar_stub)
+
+from refweaver.enrich import ArticleEnricher
+from refweaver.models import Article
+
+
+def _make_article(*, doi: str | None = None, abstract: str | None = None) -> Article:
+    return Article(
+        source="openalex",
+        external_id="W1",
+        title="A test article title",
+        authors=["Author One"],
+        doi=doi,
+        abstract=abstract,
+    )
+
+
+def _make_enricher() -> ArticleEnricher:
+    enricher = ArticleEnricher.__new__(ArticleEnricher)
+    enricher.use_llm_extractor = False
+    return enricher
+
+
+def test_fill_abstract_retries_doi_strategies_after_title_finds_doi_cross_api():
+    enricher = _make_enricher()
+    article = _make_article()
+
+    calls = {"cross_api": 0, "crossref": 0}
+
+    enricher._fill_from_same_source = lambda a: a
+
+    def cross_api(a: Article) -> Article:
+        calls["cross_api"] += 1
+        if calls["cross_api"] == 1:
+            return a
+        return a.model_copy(update={"abstract": "Filled by cross-api"})
+
+    def crossref(a: Article) -> Article:
+        calls["crossref"] += 1
+        return a
+
+    enricher._fill_from_cross_api = cross_api
+    enricher.enrich_from_crossref = crossref
+    enricher.enrich_from_pdf_doi = lambda a: a
+    enricher._extract_with_llm = lambda a: a
+    enricher.enrich_from_title = lambda a: a.model_copy(update={"doi": "10.1000/test"})
+
+    result = enricher.fill_abstract(article)
+
+    assert result.abstract == "Filled by cross-api"
+    assert calls["cross_api"] == 2
+    assert calls["crossref"] == 0
+
+
+def test_fill_abstract_retries_doi_strategies_after_title_finds_doi_crossref():
+    enricher = _make_enricher()
+    article = _make_article()
+
+    calls = {"cross_api": 0, "crossref": 0}
+
+    enricher._fill_from_same_source = lambda a: a
+
+    def cross_api(a: Article) -> Article:
+        calls["cross_api"] += 1
+        return a
+
+    def crossref(a: Article) -> Article:
+        calls["crossref"] += 1
+        if calls["crossref"] == 1:
+            return a
+        return a.model_copy(update={"abstract": "Filled by crossref"})
+
+    enricher._fill_from_cross_api = cross_api
+    enricher.enrich_from_crossref = crossref
+    enricher.enrich_from_pdf_doi = lambda a: a
+    enricher._extract_with_llm = lambda a: a
+    enricher.enrich_from_title = lambda a: a.model_copy(update={"doi": "10.1000/test"})
+
+    result = enricher.fill_abstract(article)
+
+    assert result.abstract == "Filled by crossref"
+    assert calls["cross_api"] == 2
+    assert calls["crossref"] == 2
+
+
+def test_fill_abstract_doi_already_present_skips_title_search():
+    enricher = _make_enricher()
+    article = _make_article(doi="10.1000/existing")
+
+    called_title = False
+
+    enricher._fill_from_same_source = lambda a: a
+    enricher._fill_from_cross_api = lambda a: a
+    enricher.enrich_from_crossref = lambda a: a
+    enricher.enrich_from_pdf_doi = lambda a: a
+    enricher._extract_with_llm = lambda a: a
+
+    def title_search(a: Article) -> Article:
+        nonlocal called_title
+        called_title = True
+        return a
+
+    enricher.enrich_from_title = title_search
+
+    enricher.fill_abstract(article)
+
+    assert called_title is False
+
+
+def test_fill_abstract_title_search_failure_does_not_rerun_doi_strategies():
+    enricher = _make_enricher()
+    article = _make_article()
+
+    calls = {"cross_api": 0, "crossref": 0}
+
+    enricher._fill_from_same_source = lambda a: a
+
+    def cross_api(a: Article) -> Article:
+        calls["cross_api"] += 1
+        return a
+
+    def crossref(a: Article) -> Article:
+        calls["crossref"] += 1
+        return a
+
+    enricher._fill_from_cross_api = cross_api
+    enricher.enrich_from_crossref = crossref
+    enricher.enrich_from_pdf_doi = lambda a: a
+    enricher._extract_with_llm = lambda a: a
+    enricher.enrich_from_title = lambda a: a
+
+    enricher.fill_abstract(article)
+
+    assert calls["cross_api"] == 1
+    assert calls["crossref"] == 0


### PR DESCRIPTION
### Motivation

- Ensure that when a title-based search discovers a DOI but leaves the abstract missing, DOI-driven strategies (cross-API and CrossRef) are attempted before giving up.

### Description

- After `enrich_from_title(article)` in `fill_abstract`, if the article now has a `doi` but still lacks an `abstract`, the code re-runs `_fill_from_cross_api` and then `enrich_from_crossref` (each guarded by their existing `try_cross_api`/`try_crossref` flags) and returns early if either fills the abstract.
- Added focused unit tests in `tests/test_enrich.py` covering: title search returning DOI-only then cross-API fills abstract, title search returning DOI-only then CrossRef fills abstract, title search is skipped when DOI already exists, and title search failure does not cause extra DOI-strategy reruns.
- Files modified: `src/refweaver/enrich.py` (logic change) and `tests/test_enrich.py` (new tests and lightweight import stubs for third-party modules used at import time).

### Testing

- Ran `python -m py_compile src/refweaver/enrich.py tests/test_enrich.py`, which succeeded.
- Ran `pytest -q tests/test_enrich.py`, which could not complete in this environment due to import/runtime issues during collection (initial missing optional deps such as `loguru`/`pyalex` were stubbed, but test collection later hit a `SyntaxError` in `src/refweaver/retry.py` in this environment), so full pytest validation could not finish here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0b144071083248c1a9b57a9439468)