### PR TITLE
Normalize outbound HTTP identity headers with env overrides

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ SEMANTIC_SCHOLAR_API_KEY=
 # Unpaywall (optional, but recommended)
 UNPAYWALL_EMAIL=user@example.com
 
+# Outbound HTTP identity headers (optional)
+REFWEAVER_HTTP_REFERER=https://example.com/refweaver
+REFWEAVER_HTTP_TITLE=RefWeaver Academic Search
+REFWEAVER_CONTACT_EMAIL=contact@example.com
+
 # Search adapter toggles
 REFWEAVER_USE_SEMANTIC_SCHOLAR=true
 REFWEAVER_USE_OPENALEX=true

--- a/docs/API.md
+++ b/docs/API.md
@@ -459,3 +459,6 @@ For request-size middleware failures, parse the top-level envelope:
 - `REFWEAVER_MAX_REQUEST_BYTES`: Max request body size in bytes.
 - `OPENALEX_EMAIL`: Optional OpenAlex config used by enrichment.
 - `SEMANTIC_SCHOLAR_API_KEY`: Optional Semantic Scholar config used by enrichment.
+- `REFWEAVER_HTTP_REFERER`: Outbound `HTTP-Referer` identity for OpenRouter/Perplexity requests.
+- `REFWEAVER_HTTP_TITLE`: Outbound `X-Title` identity for OpenRouter/Perplexity requests.
+- `REFWEAVER_CONTACT_EMAIL`: Contact email used in outbound `User-Agent` for Crossref requests.

--- a/src/refweaver/adapters/perplexity.py
+++ b/src/refweaver/adapters/perplexity.py
@@ -8,6 +8,7 @@ import requests
 from loguru import logger
 from pydantic import HttpUrl
 
+from refweaver.http_identity import build_openrouter_identity_headers
 from refweaver.models import Article
 from refweaver.rate_limit import rate_limit
 from refweaver.retry import retry_call
@@ -67,8 +68,7 @@ class PerplexityAdapter:
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
-            "HTTP-Referer": "https://github.com/dmunozg/refweaver",  # Required by OpenRouter
-            "X-Title": "RefWeaver Academic Search",  # Helps with rate limits
+            **build_openrouter_identity_headers(),
         }
 
         payload = {

--- a/src/refweaver/api/main.py
+++ b/src/refweaver/api/main.py
@@ -13,6 +13,7 @@ from refweaver.api.routes.runs import router as runs_router
 from refweaver.api.routes.search import router as search_router
 from refweaver.api.settings import SETTINGS
 from refweaver.db.session import get_engine
+from refweaver.http_identity import validate_http_identity_config
 
 
 def create_app() -> FastAPI:
@@ -21,6 +22,7 @@ def create_app() -> FastAPI:
 
     @app.on_event("startup")
     def _startup() -> None:
+        validate_http_identity_config()
         app.state.engine = get_engine(SETTINGS.database_url)
 
     @app.on_event("shutdown")

--- a/src/refweaver/http_identity.py
+++ b/src/refweaver/http_identity.py
@@ -1,0 +1,43 @@
+"""Helpers for normalized outbound HTTP identity headers."""
+
+import os
+
+DEFAULT_HTTP_REFERER = "https://example.com/refweaver"
+DEFAULT_CONTACT_EMAIL = "contact@example.com"
+DEFAULT_HTTP_TITLE = "RefWeaver Academic Search"
+
+
+def _get_env_str(name: str, default: str) -> str:
+    """Read an environment variable with whitespace trimming and fallback."""
+    raw = os.getenv(name)
+    if not raw:
+        return default
+
+    value = raw.strip()
+    return value or default
+
+
+def get_http_referer() -> str:
+    """Return the outbound HTTP referer identity value."""
+    return _get_env_str("REFWEAVER_HTTP_REFERER", DEFAULT_HTTP_REFERER)
+
+
+def get_contact_email() -> str:
+    """Return the outbound contact email identity value."""
+    return _get_env_str("REFWEAVER_CONTACT_EMAIL", DEFAULT_CONTACT_EMAIL)
+
+
+def build_crossref_user_agent() -> str:
+    """Build a User-Agent string that includes a contact email."""
+    return f"RefWeaver/1.0 (mailto:{get_contact_email()})"
+
+
+
+def get_http_title() -> str:
+    """Return the outbound HTTP title identity value."""
+    return _get_env_str("REFWEAVER_HTTP_TITLE", DEFAULT_HTTP_TITLE)
+
+
+def build_openrouter_identity_headers() -> dict[str, str]:
+    """Build identity headers required/recommended by OpenRouter."""
+    return {"HTTP-Referer": get_http_referer(), "X-Title": get_http_title()}

--- a/src/refweaver/http_identity.py
+++ b/src/refweaver/http_identity.py
@@ -2,6 +2,8 @@
 
 import os
 
+from loguru import logger
+
 DEFAULT_HTTP_REFERER = "https://example.com/refweaver"
 DEFAULT_CONTACT_EMAIL = "contact@example.com"
 DEFAULT_HTTP_TITLE = "RefWeaver Academic Search"
@@ -32,7 +34,6 @@ def build_crossref_user_agent() -> str:
     return f"RefWeaver/1.0 (mailto:{get_contact_email()})"
 
 
-
 def get_http_title() -> str:
     """Return the outbound HTTP title identity value."""
     return _get_env_str("REFWEAVER_HTTP_TITLE", DEFAULT_HTTP_TITLE)
@@ -41,3 +42,24 @@ def get_http_title() -> str:
 def build_openrouter_identity_headers() -> dict[str, str]:
     """Build identity headers required/recommended by OpenRouter."""
     return {"HTTP-Referer": get_http_referer(), "X-Title": get_http_title()}
+
+
+def validate_http_identity_config() -> None:
+    """Warn when outbound HTTP identity settings still use placeholder defaults."""
+    if get_http_referer() == DEFAULT_HTTP_REFERER:
+        logger.warning(
+            "REFWEAVER_HTTP_REFERER is using placeholder default '{}'; set it to your project URL",
+            DEFAULT_HTTP_REFERER,
+        )
+
+    if get_http_title() == DEFAULT_HTTP_TITLE:
+        logger.warning(
+            "REFWEAVER_HTTP_TITLE is using default '{}'; set it to your client/app name",
+            DEFAULT_HTTP_TITLE,
+        )
+
+    if get_contact_email() == DEFAULT_CONTACT_EMAIL:
+        logger.warning(
+            "REFWEAVER_CONTACT_EMAIL is using placeholder default '{}'; set it to a monitored contact email",
+            DEFAULT_CONTACT_EMAIL,
+        )

--- a/src/refweaver/models.py
+++ b/src/refweaver/models.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, HttpUrl
 
+from refweaver.http_identity import build_crossref_user_agent
+
 
 class Sentence(BaseModel):
     """A sentence from a manuscript with reference analysis metadata."""
@@ -313,7 +315,7 @@ class Article(BaseModel):
             url = f"https://doi.org/{self.doi}"
             headers = {
                 "Accept": "application/x-bibtex",
-                "User-Agent": "RefWeaver/1.0 (mailto:diego@asgamers.net)",
+                "User-Agent": build_crossref_user_agent(),
             }
 
             from refweaver.rate_limit import rate_limit

--- a/src/refweaver/worker.py
+++ b/src/refweaver/worker.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from rq import Worker
 
+from refweaver.http_identity import validate_http_identity_config
 from refweaver.queue import get_queue
 
 
 def main() -> None:
+    validate_http_identity_config()
     queue = get_queue()
     worker = Worker([queue], connection=queue.connection)
     worker.work()

--- a/tests/test_api_engine_lifecycle.py
+++ b/tests/test_api_engine_lifecycle.py
@@ -11,3 +11,14 @@ def test_engine_initialized_once_on_startup() -> None:
         with TestClient(app):
             pass
         assert mocked.call_count == 1
+
+
+def test_identity_config_validated_on_startup() -> None:
+    with (
+        patch("refweaver.api.main.get_engine"),
+        patch("refweaver.api.main.validate_http_identity_config") as mocked_validate,
+    ):
+        app = create_app()
+        with TestClient(app):
+            pass
+        assert mocked_validate.call_count == 1

--- a/tests/test_http_identity_headers.py
+++ b/tests/test_http_identity_headers.py
@@ -1,13 +1,16 @@
 """Tests for outbound HTTP identity header construction."""
 
+from pytest import MonkeyPatch
+
 from refweaver.http_identity import (
     build_crossref_user_agent,
     build_openrouter_identity_headers,
+    validate_http_identity_config,
 )
 from refweaver.models import Article
 
 
-def test_openrouter_identity_headers_use_env_overrides(monkeypatch):
+def test_openrouter_identity_headers_use_env_overrides(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("REFWEAVER_HTTP_REFERER", "https://refweaver.example/agent")
     monkeypatch.setenv("REFWEAVER_HTTP_TITLE", "RefWeaver Test Client")
 
@@ -17,7 +20,7 @@ def test_openrouter_identity_headers_use_env_overrides(monkeypatch):
     assert headers["X-Title"] == "RefWeaver Test Client"
 
 
-def test_crossref_user_agent_uses_contact_email_env_override(monkeypatch):
+def test_crossref_user_agent_uses_contact_email_env_override(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("REFWEAVER_CONTACT_EMAIL", "ops@example.org")
 
     captured: dict[str, object] = {}
@@ -28,7 +31,7 @@ def test_crossref_user_agent_uses_contact_email_env_override(monkeypatch):
         def raise_for_status(self) -> None:
             return None
 
-    def fake_get(url, headers, timeout):
+    def fake_get(url: str, headers: dict[str, str], timeout: float) -> _CrossrefResponse:
         captured["headers"] = headers
         return _CrossrefResponse()
 
@@ -49,3 +52,23 @@ def test_crossref_user_agent_uses_contact_email_env_override(monkeypatch):
     assert isinstance(headers, dict)
     assert headers["User-Agent"] == build_crossref_user_agent()
     assert enriched.title == "Updated title"
+
+
+def test_validate_http_identity_config_warns_on_default_placeholders(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("REFWEAVER_HTTP_REFERER", raising=False)
+    monkeypatch.delenv("REFWEAVER_CONTACT_EMAIL", raising=False)
+
+    warnings: list[str] = []
+
+    def fake_warning(message: str, *_args: object, **_kwargs: object) -> None:
+        warnings.append(message)
+
+    monkeypatch.setattr("refweaver.http_identity.logger.warning", fake_warning)
+
+    validate_http_identity_config()
+
+    assert len(warnings) == 3
+    assert any("REFWEAVER_HTTP_REFERER" in warning for warning in warnings)
+    assert any("REFWEAVER_CONTACT_EMAIL" in warning for warning in warnings)

--- a/tests/test_http_identity_headers.py
+++ b/tests/test_http_identity_headers.py
@@ -1,0 +1,51 @@
+"""Tests for outbound HTTP identity header construction."""
+
+from refweaver.http_identity import (
+    build_crossref_user_agent,
+    build_openrouter_identity_headers,
+)
+from refweaver.models import Article
+
+
+def test_openrouter_identity_headers_use_env_overrides(monkeypatch):
+    monkeypatch.setenv("REFWEAVER_HTTP_REFERER", "https://refweaver.example/agent")
+    monkeypatch.setenv("REFWEAVER_HTTP_TITLE", "RefWeaver Test Client")
+
+    headers = build_openrouter_identity_headers()
+
+    assert headers["HTTP-Referer"] == "https://refweaver.example/agent"
+    assert headers["X-Title"] == "RefWeaver Test Client"
+
+
+def test_crossref_user_agent_uses_contact_email_env_override(monkeypatch):
+    monkeypatch.setenv("REFWEAVER_CONTACT_EMAIL", "ops@example.org")
+
+    captured: dict[str, object] = {}
+
+    class _CrossrefResponse:
+        text = "@article{x,title={Updated title},author={Doe, Jane},year={2024}}"
+
+        def raise_for_status(self) -> None:
+            return None
+
+    def fake_get(url, headers, timeout):
+        captured["headers"] = headers
+        return _CrossrefResponse()
+
+    monkeypatch.setattr("requests.get", fake_get)
+    monkeypatch.setattr("refweaver.rate_limit.rate_limit", lambda *_: None)
+
+    article = Article(
+        source="openalex",
+        external_id="W1",
+        title="Original",
+        authors=["A"],
+        doi="10.1000/test",
+    )
+
+    enriched = article.enrich_from_crossref()
+
+    headers = captured["headers"]
+    assert isinstance(headers, dict)
+    assert headers["User-Agent"] == build_crossref_user_agent()
+    assert enriched.title == "Updated title"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,29 @@
+from pytest import MonkeyPatch
+
+from refweaver.worker import main
+
+
+def test_worker_validates_identity_config_on_startup(monkeypatch: MonkeyPatch) -> None:
+    class DummyQueue:
+        connection = object()
+
+    class DummyWorker:
+        def __init__(self, queues: list[object], connection: object) -> None:
+            self.queues = queues
+            self.connection = connection
+
+        def work(self) -> None:
+            return None
+
+    called = {"validate": 0}
+
+    def fake_validate() -> None:
+        called["validate"] += 1
+
+    monkeypatch.setattr("refweaver.worker.get_queue", lambda: DummyQueue())
+    monkeypatch.setattr("refweaver.worker.Worker", DummyWorker)
+    monkeypatch.setattr("refweaver.worker.validate_http_identity_config", fake_validate)
+
+    main()
+
+    assert called["validate"] == 1


### PR DESCRIPTION
### Motivation
- Remove hardcoded personal contact/identity strings from outbound requests and make them configurable at runtime with safe, neutral defaults.
- Ensure OpenRouter/Perplexity and Crossref requests present normalized identity headers that can be overridden in deployments for contact/troubleshooting purposes.

### Description
- Added a new helper module `src/refweaver/http_identity.py` that exposes `build_openrouter_identity_headers()`, `build_crossref_user_agent()`, and small getters that read `REFWEAVER_HTTP_REFERER`, `REFWEAVER_HTTP_TITLE`, and `REFWEAVER_CONTACT_EMAIL` with neutral fallbacks.
- Updated `PerplexityAdapter._make_request` to include OpenRouter identity headers via `build_openrouter_identity_headers()` instead of hardcoded `HTTP-Referer`/`X-Title` values.
- Updated `Article.enrich_from_crossref` to build the `User-Agent` header via `build_crossref_user_agent()` instead of embedding a personal email.
- Documented the new environment variables in `docs/API.md` and added example entries to `.env.example`, and added focused unit tests in `tests/test_http_identity_headers.py` to assert env overrides are respected.

### Testing
- Added unit tests in `tests/test_http_identity_headers.py` which exercise `build_openrouter_identity_headers()` and the Crossref `User-Agent` usage, and ran them with `pytest -q tests/test_http_identity_headers.py` which passed.
- The new tests executed successfully (2 tests passed) in the local test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0b12df3c08324a73dff5741d506d8)