### PR TITLE
Add dedicated `migrate` compose service and gate api/worker startup

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,23 @@
 services:
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: ["sh", "-c", "echo Migration job completed."]
+    env_file:
+      - .env
+    environment:
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:?err}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:?err}
+      LLM_BASE_URL: http://host.containers.internal:11435/v1
+      DATABASE_URL: postgresql+psycopg://refweaver:${DB_PASSWORD:?err}@postgres:5432/refweaver
+      REFWEAVER_REDIS_URL: redis://redis:6379/0
+      REFWEAVER_JOB_TIMEOUT: "259200"
+      REFWEAVER_RUN_MIGRATIONS: "1"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   api:
     build:
       context: .
@@ -15,6 +34,7 @@ services:
       DATABASE_URL: postgresql+psycopg://refweaver:${DB_PASSWORD:?err}@postgres:5432/refweaver
       REFWEAVER_REDIS_URL: redis://redis:6379/0
       REFWEAVER_JOB_TIMEOUT: "259200"
+      REFWEAVER_RUN_MIGRATIONS: "0"
     depends_on:
       redis:
         condition: service_healthy
@@ -22,6 +42,8 @@ services:
         condition: service_healthy
       worker:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
 
   worker:
     build:
@@ -37,11 +59,14 @@ services:
       DATABASE_URL: postgresql+psycopg://refweaver:${DB_PASSWORD:?err}@postgres:5432/refweaver
       REFWEAVER_REDIS_URL: redis://redis:6379/0
       REFWEAVER_JOB_TIMEOUT: "259200"
+      REFWEAVER_RUN_MIGRATIONS: "0"
     depends_on:
       redis:
         condition: service_healthy
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD-SHELL", "tr '\\0' ' ' < /proc/1/cmdline | grep -q 'refweaver.worker'"]
       interval: 10s

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 PROJECT_ROOT="${PROJECT_ROOT:-/app}"
+RUN_MIGRATIONS="${REFWEAVER_RUN_MIGRATIONS:-1}"
 
 cd "$PROJECT_ROOT"
 
@@ -15,11 +16,15 @@ if [ ! -d "$PROJECT_ROOT/alembic" ]; then
   exit 1
 fi
 
-echo "Running database migrations..."
-if ! alembic -c "$PROJECT_ROOT/alembic.ini" upgrade head; then
-  echo "Database migration failed; aborting startup." >&2
-  exit 1
+if [ "$RUN_MIGRATIONS" = "1" ]; then
+  echo "Running database migrations..."
+  if ! alembic -c "$PROJECT_ROOT/alembic.ini" upgrade head; then
+    echo "Database migration failed; aborting startup." >&2
+    exit 1
+  fi
+  echo "Database migrations applied."
+else
+  echo "Skipping database migrations (REFWEAVER_RUN_MIGRATIONS=$RUN_MIGRATIONS)."
 fi
-echo "Database migrations applied."
 
 exec "$@"


### PR DESCRIPTION
### Motivation
- Prevent concurrent `alembic upgrade head` runs from `api` and `worker` during cold startup which can race and cause migration failures (duplicate key / `alembic_version` errors). 
- Make `docker compose up` deterministic so schema migrations run once before app processes start.

### Description
- Added a one-shot `migrate` service to `compose.yml` that runs migrations as the migration owner and sets `REFWEAVER_RUN_MIGRATIONS=1` for that service. 
- Disabled in-process migrations for `api` and `worker` by setting `REFWEAVER_RUN_MIGRATIONS=0` in their environments. 
- Gated `api` and `worker` startup on `migrate` completion by adding `depends_on: condition: service_completed_successfully`. 
- Made `docker-entrypoint.sh` honor `REFWEAVER_RUN_MIGRATIONS` (default `1`) so the same image can be used for the migration job or normal app services safely.

### Testing
- Ran shell syntax check on the entrypoint with `sh -n docker-entrypoint.sh` which passed. 
- Attempted `docker compose -f compose.yml config` to validate Compose wiring but the Docker CLI is not available in this environment so the check could not be executed. 
- No runtime containerized tests were run in this environment due to missing Docker support.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0bd5db6048324891ffc5dcf06d477)